### PR TITLE
Post: integrate Twitter preview card (text only)

### DIFF
--- a/layout/post.jade
+++ b/layout/post.jade
@@ -8,6 +8,10 @@ block site_title
 block description
     - var desc = page.desc || strip_html(page.content).replace(/^\s*/, '').replace(/\s*$/, '').substring(0, 150);
     meta(name="description", content=desc)
+    meta(name="og:description", content=desc)
+    meta(name="twitter:site", content=config.title)
+    meta(name="twitter:title", content=page.title)
+    meta(name="twitter:card", content="summary")
 
 block content
     .autopagerize_page_element: .content: .post-page


### PR DESCRIPTION
Card with image preview is a future work item (on the level of "it's nice to have it"), I anticipate it will be a bit tricky unless the post metadata gets extended.

Tested in live PROD environment.

![image](https://user-images.githubusercontent.com/6284353/126897183-20717566-efeb-4ec6-9b7d-8c4424681bdc.png)
